### PR TITLE
134 recreate the project information tab in prototype

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -19,5 +19,6 @@ $govuk-assets-path: '/govuk/assets/';
 @import "patterns/task-list";
 @import "patterns/school-list";
 @import "patterns/sub-navigation";
+@import "patterns/empty-tag";
 
 // Add extra styles here, or re-organise the Sass files in whichever way makes most sense to you

--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -18,5 +18,6 @@ $govuk-assets-path: '/govuk/assets/';
 @import "patterns/step-by-step-related";
 @import "patterns/task-list";
 @import "patterns/school-list";
+@import "patterns/sub-navigation";
 
 // Add extra styles here, or re-organise the Sass files in whichever way makes most sense to you

--- a/app/assets/sass/patterns/_empty-tag.scss
+++ b/app/assets/sass/patterns/_empty-tag.scss
@@ -1,0 +1,22 @@
+ .empty {
+    display: inline-block;
+    border: 2px solid;
+    outline-offset: -2px;
+    color: $govuk-secondary-text-colour;
+    background-color:  govuk-colour("white");
+    letter-spacing: 1px;
+    text-decoration: none;
+    text-transform: uppercase;
+    font-family: "GDS Transport", arial, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    font-weight: 700;
+    font-size: 1rem;
+    font-size: 0.875rem;
+    line-height: 1;
+    padding-top: 3px;
+    padding-right: 8px;
+    padding-bottom: 3px;
+    padding-left: 8px;
+    margin-right: 8px;
+  }

--- a/app/assets/sass/patterns/_sub-navigation.scss
+++ b/app/assets/sass/patterns/_sub-navigation.scss
@@ -1,0 +1,105 @@
+.sub-navigation {
+  margin-bottom: govuk-spacing(7);
+}
+
+.sub-navigation__list {
+  font-size: 0;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+
+  @include govuk-media-query($from: tablet) {
+    box-shadow: inset 0 -1px 0 $govuk-border-colour;
+    width: 100%;
+  }
+
+  @include govuk-if-ie8 {
+    border-bottom: 1px solid $govuk-border-colour;
+  }
+}
+
+.sub-navigation__item {
+  @include govuk-font(19);
+  box-shadow: inset 0 -1px 0 $govuk-border-colour;
+  display: block;
+  margin-top: -1px;
+
+  &:last-child {
+    box-shadow: none;
+  }
+
+  @include govuk-media-query($from: tablet) {
+    box-shadow: none;
+    display: inline-block;
+    margin-right: govuk-spacing(4);
+    margin-top: 0;
+  }
+}
+
+
+.sub-navigation__link {
+  @include govuk-link-common;
+  @include govuk-link-style-default;
+  display: block;
+  padding-top: 12px;
+  padding-bottom: 12px;
+  padding-left: govuk-spacing(3);
+  text-decoration: none;
+  position: relative;
+
+  @include govuk-media-query($from: tablet) {
+    padding-left: 0;
+  }
+
+  &:link,
+  &:visited {
+    color: $govuk-link-colour;
+  }
+
+  &:hover {
+    color: govuk-tint($govuk-link-colour, 25);
+  }
+
+  &:focus {
+    color: govuk-colour("black");
+    position: relative;
+    box-shadow: none;
+  }
+
+  &:focus:before {
+    background-color: govuk-colour("black");
+    content: "";
+    display: block;
+    width: 100%;
+    position: absolute; bottom: 0; left: 0; right: 0;
+    height: 5px;
+  }
+}
+
+
+.sub-navigation__link[aria-current="page"] {
+  color: $govuk-link-active-colour;
+  position: relative;
+  text-decoration: none;
+
+  &:before {
+    background-color: $govuk-link-colour;
+    content: "";
+    display: block;
+    height: 100%;
+    position: absolute; bottom: 0; left: 0;
+    width: 5px;
+
+    @include govuk-media-query($from: tablet) {
+      height: 5px;
+      width: 100%;
+    }
+
+  }
+
+  &:focus:before {
+    background-color: govuk-colour("black");
+  }
+
+}

--- a/app/routes.js
+++ b/app/routes.js
@@ -5,5 +5,8 @@ const router = express.Router()
   require('./routes/0-1/routes.js')(router);
   require('./routes/0-1/project-kick-off.js')(router);
 
+  require('./routes/0-2/routes.js')(router);
+  require('./routes/0-2/project-kick-off.js')(router);
+
 
 module.exports = router

--- a/app/routes/0-2/project-kick-off.js
+++ b/app/routes/0-2/project-kick-off.js
@@ -1,0 +1,94 @@
+module.exports = function (router) {
+
+  var version = "0-2";
+
+  router.get('/' + version + '/project-kick-off/save-proforma', function (req, res) {
+    res.render(version + '/project-kick-off/save-proforma', {})
+  })
+
+  router.post('/' + version + '/project-kick-off/save-proforma', function (req, res) {
+    res.redirect('proforma-url')
+  })
+
+
+  router.get('/' + version + '/project-kick-off/proforma-url', function (req, res) {
+    res.render(version + '/project-kick-off/proforma-url', {})
+  })
+
+  router.post('/' + version + '/project-kick-off/proforma-url', function (req, res) {
+    res.redirect('check-trust-model-docs')
+  })
+
+
+  router.get('/' + version + '/project-kick-off/check-trust-model-docs', function (req, res) {
+    res.render(version + '/project-kick-off/check-trust-model-docs', {})
+  })
+
+  router.post('/' + version + '/project-kick-off/check-trust-model-docs', function (req, res) {
+    res.redirect('trust-model-docs-url')
+  })
+
+
+  router.get('/' + version + '/project-kick-off/trust-model-docs-url', function (req, res) {
+    res.render(version + '/project-kick-off/trust-model-docs-url', {})
+  })
+
+  router.post('/' + version + '/project-kick-off/trust-model-docs-url', function (req, res) {
+    res.redirect('check-academy-order')
+  })
+
+
+  router.get('/' + version + '/project-kick-off/check-academy-order', function (req, res) {
+    res.render(version + '/project-kick-off/check-academy-order', {})
+  })
+
+  router.post('/' + version + '/project-kick-off/check-academy-order', function (req, res) {
+    res.redirect('academy-order-url')
+  })
+
+
+  router.get('/' + version + '/project-kick-off/academy-order-url', function (req, res) {
+    res.render(version + '/project-kick-off/academy-order-url', {})
+  })
+
+  router.post('/' + version + '/project-kick-off/academy-order-url', function (req, res) {
+    res.redirect('check-application-to-convert')
+  })
+
+
+  router.get('/' + version + '/project-kick-off/check-application-to-convert', function (req, res) {
+    res.render(version + '/project-kick-off/check-application-to-convert', {})
+  })
+
+  router.post('/' + version + '/project-kick-off/check-application-to-convert', function (req, res) {
+    res.redirect('application-to-convert-url')
+  })
+
+
+  router.get('/' + version + '/project-kick-off/application-to-convert-url', function (req, res) {
+    res.render(version + '/project-kick-off/application-to-convert-url', {})
+  })
+
+  router.post('/' + version + '/project-kick-off/application-to-convert-url', function (req, res) {
+    res.redirect('identify-things-to-discuss')
+  })
+
+
+  router.get('/' + version + '/project-kick-off/identify-things-to-discuss', function (req, res) {
+    res.render(version + '/project-kick-off/identify-things-to-discuss', {})
+  })
+
+  router.post('/' + version + '/project-kick-off/identify-things-to-discuss', function (req, res) {
+    res.redirect('complete-handover-meeting')
+  })
+
+
+  router.get('/' + version + '/project-kick-off/complete-handover-meeting', function (req, res) {
+    res.render(version + '/project-kick-off/complete-handover-meeting', {})
+  })
+
+  router.post('/' + version + '/project-kick-off/complete-handover-meeting', function (req, res) {
+    res.redirect('check-answers')
+  })
+
+}

--- a/app/routes/0-2/routes.js
+++ b/app/routes/0-2/routes.js
@@ -1,0 +1,5 @@
+module.exports = function (router) {
+
+  var version = "0-2";
+
+}

--- a/app/views/0-2/includes/phase.html
+++ b/app/views/0-2/includes/phase.html
@@ -1,0 +1,7 @@
+{% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+{{ govukPhaseBanner({
+  tag: {
+    text: "beta"
+  },
+  html: 'This is a new service - your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+}) }}

--- a/app/views/0-2/project-information.html
+++ b/app/views/0-2/project-information.html
@@ -1,0 +1,550 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Complete conversions transfers and changes
+{% endblock %}
+
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block beforeContent %}
+  {% include "./includes/phase.html" %}
+  <a href="start" class="govuk-back-link">Back to all projects</a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <span class="govuk-caption-l">URN 102062 - Voluntary aided school</span>
+      <h1 class="govuk-heading-l">St. Wilfred's Primary School</h1>
+      <div class="govuk-inset-text">
+        <p class="govuk-body govuk-!-margin-0">
+          <span class="govuk-!-font-weight-bold">First baseline:</span>
+          1 July 2022</p>
+        <p class="govuk-body govuk-!-margin-0">
+          <span class="govuk-!-font-weight-bold">All conditions met baseline:</span>
+          14 July 2022</p>
+          <p class="govuk-body govuk-!-margin-0">
+            <span class="govuk-!-font-weight-bold">Target opening date:</span>
+            1 August 2022</p>
+          <p class="govuk-body govuk-!-margin-0">
+            <span class="govuk-!-font-weight-bold">Incoming trust:</span>
+            Dynamics Trust</p>
+      </div>
+
+      <nav class="sub-navigation" aria-label="Sub navigation">
+        <ul class="sub-navigation__list">
+          <li class="sub-navigation__item">
+            <a class="sub-navigation__link" href="project-task-list">Project task list</a>
+          </li>
+          <li class="sub-navigation__item">
+            <a class="sub-navigation__link" aria-current="page" href="#">Project information</a>
+          </li>
+        </ul>
+      </nav>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-third">
+          <h3 class="govuk-heading-m">Jump to section</h3>
+          <p class="govuk-body govuk-!-margin-bottom-1"><a href="#projectDetails" class="govuk-link">
+            Project details</a></p>
+          <p class="govuk-body govuk-!-margin-bottom-1"><a href="#schoolDetails" class="govuk-link">
+            School details</a></p>
+          <p class="govuk-body govuk-!-margin-bottom-1"><a href="#trustDetails" class="govuk-link">
+            Trust details</a></p>
+          <p class="govuk-body govuk-!-margin-bottom-1"><a href="#localAuthorityDetails" class="govuk-link">
+            Local authority details</a></p>
+          <p class="govuk-body govuk-!-margin-bottom-1"><a href="#dioceseDetails" class="govuk-link">
+            Diocese details</a></p>
+          <p class="govuk-body govuk-!-margin-bottom-1"><a href="#solicitorDetails" class="govuk-link">
+            Solicitor details</a></p>
+        </div>
+
+        <div class="govuk-grid-column-two-thirds">
+          <h2 class="govuk-heading-l" id="projectDetails">Project details</h2>
+          <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Delivery officer
+              </dt>
+              <dd class="govuk-summary-list__value">
+                Jo Wade
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> delivery officer</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Team Lead
+              </dt>
+              <dd class="govuk-summary-list__value">
+                Sisi Wheeler
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> team lead</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Grade 6
+              </dt>
+              <dd class="govuk-summary-list__value">
+                Nikkita Reynolds
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> grade 6</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Regional delivery officer
+              </dt>
+              <dd class="govuk-summary-list__value">
+                Jovan George
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> regional delivery officer</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Academies and Maintained Schools lead
+              </dt>
+              <dd class="govuk-summary-list__value">
+                Arlo Freeman
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> Academies and maintained schools lead</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Advisory board project template
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <a class="govuk-link" href="#">sharepoint/conversions/dynamics/StWilfreds/HTBtemplate</a>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> advisory board project template URL</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Conditions from advisory board
+              </dt>
+              <dd class="govuk-summary-list__value">
+                None
+              </dd>
+              <dd class="govuk-summary-list__actions">
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Academy type and route
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <p class="govuk-body">Route: grant only - £25,000</p>
+                <p class="govuk-body">Type: converter</p>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> academy type and route</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Application to convert
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <a class="govuk-link" href="#">sharepoint/conversions/dynamics/StWilfreds/HTBtemplate</a>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> application to convert URL</span>
+                </a>
+              </dd>
+            </div>
+          </dl>
+
+          <h2 class="govuk-heading-l" id="schoolDetails">School details</h2>
+          <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Original school name
+              </dt>
+              <dd class="govuk-summary-list__value">
+                St. Wilfred's Primary School
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> original school name</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                New academy name
+              </dt>
+              <dd class="govuk-summary-list__value">
+                EMPTY
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> new academy name</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Link to school SharePoint folder Get Information About Schools Link
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <a class="govuk-link" href="#">sharepoint/conversions/dynamics/StWilfreds/GIASdata</a>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> grade 6</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Old Unique Reference Number
+              </dt>
+              <dd class="govuk-summary-list__value">
+                123456
+              </dd>
+              <dd class="govuk-summary-list__actions">
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                New Unique Reference Number
+              </dt>
+              <dd class="govuk-summary-list__value">
+                EMPTY
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> new unique reference number</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                School phase
+              </dt>
+              <dd class="govuk-summary-list__value">
+                3 to 11 (priamry)
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> school phase</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                School type
+              </dt>
+              <dd class="govuk-summary-list__value">
+                Voluntary aided
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> school type</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Headteacher
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <p class="govuk-body">Name: Mx Nour Michael</p>
+                <p class="govuk-body">Email: <a class="govuk-link" href="mailto:n.michael@stwilfreds.edu.uk">n.michael@stwilfreds.edu.uk</a></p>
+                <p class="govuk-body">Phone: 01234 111111</p>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> headteacher</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Chair of governers
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <p class="govuk-body">Name: Andrew Gilmore</p>
+                <p class="govuk-body">Email: <a class="govuk-link" href="mailto:theandrewgilmore@geocities.com">theandrewgilmore@geocities.com</a></p>
+                <p class="govuk-body">Phone: 07925 252 252</p>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> chair of governers</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Business manager
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <p class="govuk-body">Name: Adnan Castillo</p>
+                <p class="govuk-body">Email: <a class="govuk-link" href="mailto:a.castillo@stwilfreds.edu.uk">a.castillo@stwilfreds.edu.uk</a></p>
+                <p class="govuk-body">Phone: 01234 111112</p>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> business manager</span>
+                </a>
+              </dd>
+            </div>
+          </dl>
+
+          <h2 class="govuk-heading-l" id="trustDetails">Trust details</h2>
+          <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Trust SharePoint folder
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <a class="govuk-link" href="#">sharepoint/conversions/dynamics/StWilfreds/TrustInfo</a>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> trust SharePoint folder</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Incoming trust name
+              </dt>
+              <dd class="govuk-summary-list__value">
+                Dynamics Trust
+              </dd>
+              <dd class="govuk-summary-list__actions">
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Trust Unique Reference Number
+              </dt>
+              <dd class="govuk-summary-list__value">
+                11223344
+              </dd>
+              <dd class="govuk-summary-list__actions">
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Trust template
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <a class="govuk-link" href="#">KIM/conversions/dynamics/StWilfreds/TrustTemplate</a>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Phone
+              </dt>
+              <dd class="govuk-summary-list__value">
+                01234 567890
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> new unique reference number</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Trust CEO
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <p class="govuk-body">Name: Eamonn Lim</p>
+                <p class="govuk-body">Email: <a class="govuk-link" href="mailto:Lim.Eamonn@dynamicstrust.co.uk">Lim.Eamonn@dynamicstrust.co.uk</a></p>
+                <p class="govuk-body">Phone: 01234 567111</p>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> Trust CEO</span>
+                </a>
+              </dd>
+            </div>
+          </dl>
+
+          <h2 class="govuk-heading-l" id="localAuthorityDetails">Local authority details</h2>
+          <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Local authority
+              </dt>
+              <dd class="govuk-summary-list__value">
+                Warrington Borough Council
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> local authority</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Local authority contact
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <p class="govuk-body">Name: Breanna Cohen</p>
+                <p class="govuk-body">Email: <a class="govuk-link" href="mailto:breannaCOHEN2@warringtonbc.org">breannaCOHEN2@warringtonbc.org</a></p>
+                <p class="govuk-body">Phone: 07925 333 444</p>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> Trust CEO</span>
+                </a>
+              </dd>
+            </div>
+          </dl>
+
+          <h2 class="govuk-heading-l" id="dioceseDetails">Diocese details</h2>
+          <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Diocese
+              </dt>
+              <dd class="govuk-summary-list__value">
+                Warrington
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> diocese</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Diocese contact
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <p class="govuk-body">Name: Delores Madden</p>
+                <p class="govuk-body">Email: <a class="govuk-link" href="mailto:delores-madded@chesterdioceses.co.uk">delores-madded@chesterdioceses.co.uk</a></p>
+                <p class="govuk-body">Phone: 07925 111 222</p>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> Trust CEO</span>
+                </a>
+              </dd>
+            </div>
+          </dl>
+
+          <h2 class="govuk-heading-l" id="solicitorDetails">Solicitor details</h2>
+          <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                School solicitors
+              </dt>
+              <dd class="govuk-summary-list__value">
+                Hargreevs and Zemeckis
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> School solicitor's name</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                School solicitor's contact
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <p class="govuk-body">Name: <span class="empty">Empty</span></p>
+                <p class="govuk-body">Email: <span class="empty">Empty</span></p>
+                <p class="govuk-body">Phone: <span class="empty">Empty</span></p>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> School solicitor's contact</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Local authority solicitors
+              </dt>
+              <dd class="govuk-summary-list__value">
+                Rankin, Rankin and Krause
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> Local authority solicitor's name</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Local authority solicitor's contact
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <p class="govuk-body">Name: <span class="empty">Empty</span></p>
+                <p class="govuk-body">Email: <span class="empty">Empty</span></p>
+                <p class="govuk-body">Phone: <span class="empty">Empty</span></p>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> Local authority solicitor's contact</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Diocese solicitors
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <span class="empty">Empty</span>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> Diocese solicitor's name</span>
+                </a>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                Diocese solicitor's contact
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <p class="govuk-body">Name: <span class="empty">Empty</span></p>
+                <p class="govuk-body">Email: <span class="empty">Empty</span></p>
+                <p class="govuk-body">Phone: <span class="empty">Empty</span></p>
+              </dd>
+              <dd class="govuk-summary-list__actions">
+                <a class="govuk-link" href="#">
+                  Change<span class="govuk-visually-hidden"> Diocese solicitor's contact</span>
+                </a>
+              </dd>
+            </div>
+          </dl>
+
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/0-2/project-kick-off/academy-order-url.html
+++ b/app/views/0-2/project-kick-off/academy-order-url.html
@@ -1,0 +1,37 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Complete conversions transfers and changes
+{% endblock %}
+
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block beforeContent %}
+  {% include "../includes/phase.html" %}
+  <a href="../project-task-list" class="govuk-back-link">Back to task list</a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <form action="academy-order-url" method="post" class="form">
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                  <span class="govuk-caption-l">St. Wilfred's Primary School</span>
+                  <h1 class="govuk-fieldset__heading" for="academyOrderUrl">What is the URL for the
+                    school's academy order document?</h1>
+                </legend>
+                <input class="govuk-input" id="academyOrderUrl" name="academyOrderUrl" type="text" value="{{data['academyOrderUrl']}}">
+              </fieldset>
+            </div>
+            {{ govukButton({ text: "Continue" }) }}
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/0-2/project-kick-off/application-to-convert-url.html
+++ b/app/views/0-2/project-kick-off/application-to-convert-url.html
@@ -1,0 +1,38 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Complete conversions transfers and changes
+{% endblock %}
+
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block beforeContent %}
+  {% include "../includes/phase.html" %}
+  <a href="../project-task-list" class="govuk-back-link">Back to task list</a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <form action="application-to-convert-url" method="post" class="form">
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                  <span class="govuk-caption-l">St. Wilfred's Primary School</span>
+                  <h1 class="govuk-fieldset__heading" for="applicationToConvertUrl">
+                    What is the URL for the school's application to convert
+                    document?</h1>
+                </legend>
+                <input class="govuk-input" id="applicationToConvertUrl" name="applicationToConvertUrl" type="text" value="{{data['trustModelDocsUrl']}}">
+              </fieldset>
+            </div>
+            {{ govukButton({ text: "Continue" }) }}
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/0-2/project-kick-off/check-academy-order.html
+++ b/app/views/0-2/project-kick-off/check-academy-order.html
@@ -1,0 +1,50 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Complete conversions transfers and changes
+{% endblock %}
+
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block beforeContent %}
+  {% include "../includes/phase.html" %}
+  <a href="../project-task-list" class="govuk-back-link">Back to task list</a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <form action="check-academy-order" method="post" class="form">
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                  <span class="govuk-caption-l">St. Wilfred's Primary School</span>
+                  <h1 class="govuk-fieldset__heading">Is the academy order
+                    document correct?</h1>
+                </legend>
+                <div class="govuk-radios" data-module="govuk-radios">
+                  <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="correctAcademyOrder" name="correctAcademyOrder" type="radio" value="Yes, the academy order document is correct" {{ checked("correctAcademyOrder", "Yes, the academy order document is correct") }}>
+                    <label class="govuk-label govuk-radios__label" for="correctAcademyOrder">
+                      Yes, the academy order document is correct
+                    </label>
+                  </div>
+                  <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="correctAcademyOrder-2" name="correctAcademyOrder" type="radio" value="No" {{ checked("correctAcademyOrder", "No") }}>
+                    <label class="govuk-label govuk-radios__label" for="correctAcademyOrder-2">
+                      No
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </div>
+            {{ govukButton({ text: "Continue" }) }}
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/0-2/project-kick-off/check-answers.html
+++ b/app/views/0-2/project-kick-off/check-answers.html
@@ -1,0 +1,170 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Complete conversions transfers and changes
+{% endblock %}
+
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block beforeContent %}
+  {% include "../includes/phase.html" %}
+  <a href="../project-task-list" class="govuk-back-link">Back to task list</a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <form action="check-trust-model-docs" method="post" class="form">
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                  <span class="govuk-caption-l">St. Wilfred's Primary School</span>
+                  <h1 class="govuk-fieldset__heading">Check answers</h1>
+                </legend>
+                <dl class="govuk-summary-list govuk-!-margin-bottom-9">
+                  <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                      Have you saved pro-forma in the school's SharePoint
+                      folder?
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                      {{data['proformaInSharepoint']}}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                      <a class="govuk-link" href="save-proforma">
+                        Change<span class="govuk-visually-hidden"> Have you
+                          saved pro-forma in the school's SharePoint folder?</span>
+                      </a>
+                    </dd>
+                  </div>
+                  <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                      What is the URL for the school's Proforma on sharepoint?
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                      {{data['proformaSharepointURL']}}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                      <a class="govuk-link" href="proforma-url">
+                        Change<span class="govuk-visually-hidden"> URL for the school's Proforma on sharepoint</span>
+                      </a>
+                    </dd>
+                  </div>
+                  <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                      Are the trust model documents correct?
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                      {{data['correctTrustModelDocs']}}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                      <a class="govuk-link" href="check-trust-model-docs">
+                        Change<span class="govuk-visually-hidden"> are the trust model documents correct</span>
+                      </a>
+                    </dd>
+                  </div>
+                  <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                      What is the URL for the school's trust model documents?
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                      {{data['trustModelDocsUrl']}}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                      <a class="govuk-link" href="trust-model-docs-url">
+                        Change<span class="govuk-visually-hidden"> the URL for the school's trust model documents</span>
+                      </a>
+                    </dd>
+                  </div>
+                  <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                      Is the academy order document correct?
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                      {{data['correctAcademyOrder']}}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                      <a class="govuk-link" href="check-academy-order">
+                        Change<span class="govuk-visually-hidden"> is the academy order document correct</span>
+                      </a>
+                    </dd>
+                  </div>
+                  <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                      What is the URL for the school's academy order document?
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                      {{data['academyOrderUrl']}}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                      <a class="govuk-link" href="academy-order-url">
+                        Change<span class="govuk-visually-hidden"> the URL for the school's academy order document</span>
+                      </a>
+                    </dd>
+                  </div>
+                  <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                      Is the application to convert document correct?
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                      {{data['applicationToConvertCorrect']}}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                      <a class="govuk-link" href="check-application-to-convert">
+                        Change<span class="govuk-visually-hidden"> Is the application to convert document correct</span>
+                      </a>
+                    </dd>
+                  </div>
+                  <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                      What is the URL for the school's application to convert document?
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                      {{data['applicationToConvertUrl']}}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                      <a class="govuk-link" href="application-to-convert-url">
+                        Change<span class="govuk-visually-hidden"> Is the application to convert document correct</span>
+                      </a>
+                    </dd>
+                  </div>
+                  <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                      Identify things to discuss with the regional delivery officer
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                      {{data['thingsToDiscussWithRegionalOfficer']}}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                      <a class="govuk-link" href="identify-things-to-discuss">
+                        Change<span class="govuk-visually-hidden"> Is the application to convert document correct</span>
+                      </a>
+                    </dd>
+                  </div>
+                  <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">
+                      Have you completed a the handover meeting with the regional delivery officer?
+                    </dt>
+                    <dd class="govuk-summary-list__value">
+                      {{data['completedHandoverMeeting']}}
+                    </dd>
+                    <dd class="govuk-summary-list__actions">
+                      <a class="govuk-link" href="complete-handover-meeting">
+                        Change<span class="govuk-visually-hidden"> Is the application to convert document correct</span>
+                      </a>
+                    </dd>
+                  </div>
+                </dl>
+
+              </fieldset>
+            </div>
+            {{ govukButton({ text: "Continue" }) }}
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/0-2/project-kick-off/check-application-to-convert.html
+++ b/app/views/0-2/project-kick-off/check-application-to-convert.html
@@ -1,0 +1,50 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Complete conversions transfers and changes
+{% endblock %}
+
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block beforeContent %}
+  {% include "../includes/phase.html" %}
+  <a href="../project-task-list" class="govuk-back-link">Back to task list</a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <form action="check-application-to-convert" method="post" class="form">
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                  <span class="govuk-caption-l">St. Wilfred's Primary School</span>
+                  <h1 class="govuk-fieldset__heading">Is the application to
+                    convert document correct?</h1>
+                </legend>
+                <div class="govuk-radios" data-module="govuk-radios">
+                  <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="applicationToConvertCorrect" name="applicationToConvertCorrect" type="radio" value="Yes, the application to convert document is correct" {{ checked("applicationToConvertCorrect", "Yes, the application to convert document is correct") }}>
+                    <label class="govuk-label govuk-radios__label" for="applicationToConvertCorrect">
+                      Yes, the application to convert document is correct
+                    </label>
+                  </div>
+                  <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="applicationToConvertCorrect-2" name="applicationToConvertCorrect" type="radio" value="No" {{ checked("applicationToConvertCorrect", "No") }}>
+                    <label class="govuk-label govuk-radios__label" for="applicationToConvertCorrect-2">
+                      No
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </div>
+            {{ govukButton({ text: "Continue" }) }}
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/0-2/project-kick-off/check-trust-model-docs.html
+++ b/app/views/0-2/project-kick-off/check-trust-model-docs.html
@@ -1,0 +1,55 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Complete conversions transfers and changes
+{% endblock %}
+
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block beforeContent %}
+  {% include "../includes/phase.html" %}
+  <a href="../project-task-list" class="govuk-back-link">Back to task list</a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <form action="check-trust-model-docs" method="post" class="form">
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                  <span class="govuk-caption-l">St. Wilfred's Primary School</span>
+                  <h1 class="govuk-fieldset__heading">Are the trust model
+                    documents correct?</h1>
+                </legend>
+                <div id="sign-in-hint" class="govuk-hint">
+                  The trust model documents should be using the 2018 or later
+                  format. If they are not they the trust will need to update
+                  their trust model documents.
+                </div>
+                <div class="govuk-radios" data-module="govuk-radios">
+                  <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="correctTrustModelDocs" name="correctTrustModelDocs" type="radio" value="Yes, the trust model documents are in the 2018 or later format" {{ checked("correctTrustModelDocs", "Yes, the trust model documents are in the 2018 or later format") }}>
+                    <label class="govuk-label govuk-radios__label" for="correctTrustModelDocs">
+                      Yes, the trust model documents are in the 2018 or later format
+                    </label>
+                  </div>
+                  <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="correctTrustModelDocs-2" name="correctTrustModelDocs" type="radio" value="No, the documents are using a pre 2018 format" {{ checked("correctTrustModelDocs", "No, the documents are using a pre 2018 format") }}>
+                    <label class="govuk-label govuk-radios__label" for="correctTrustModelDocs-2">
+                      No, the documents are using a pre 2018 format
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </div>
+            {{ govukButton({ text: "Continue" }) }}
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/0-2/project-kick-off/complete-handover-meeting.html
+++ b/app/views/0-2/project-kick-off/complete-handover-meeting.html
@@ -1,0 +1,57 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Complete conversions transfers and changes
+{% endblock %}
+
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block beforeContent %}
+  {% include "../includes/phase.html" %}
+  <a href="../project-task-list" class="govuk-back-link">Back to task list</a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <form action="complete-handover-meeting" method="post" class="form">
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                  <span class="govuk-caption-l">St. Wilfred's Primary School</span>
+                  <h1 class="govuk-fieldset__heading">Have you completed a the
+                    handover meeting with the regional delivery officer?
+                  </h1>
+                </legend>
+                <div class="govuk-radios" data-module="govuk-radios">
+                  <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="completedHandoverMeeting" name="completedHandoverMeeting" type="radio" value="Yes" {{ checked("completedHandoverMeeting", "Yes") }}>
+                    <label class="govuk-label govuk-radios__label" for="completedHandoverMeeting">
+                      Yes, my questions were answered
+                    </label>
+                  </div>
+                  <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="completedHandoverMeeting-2" name="completedHandoverMeeting" type="radio" value="Yes, but I still have questions" {{ checked("completedHandoverMeeting", "Yes, but I still have questions") }}>
+                    <label class="govuk-label govuk-radios__label" for="completedHandoverMeeting-2">
+                      Yes, but I still have questions
+                    </label>
+                  </div>
+                  <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="completedHandoverMeeting-3" name="completedHandoverMeeting" type="radio" value="No" {{ checked("completedHandoverMeeting", "No") }}>
+                    <label class="govuk-label govuk-radios__label" for="completedHandoverMeeting-3">
+                      No
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </div>
+            {{ govukButton({ text: "Continue" }) }}
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/0-2/project-kick-off/handover-with-regional-delivery-officer.html
+++ b/app/views/0-2/project-kick-off/handover-with-regional-delivery-officer.html
@@ -1,0 +1,88 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Complete conversions transfers and changes
+{% endblock %}
+
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block beforeContent %}
+  {% include "../includes/phase.html" %}
+  <a href="../project-task-list" class="govuk-back-link">Back to task list</a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <span class="govuk-caption-l">St. Wilfred's Primary School</span>
+      <h1 class="govuk-heading-l">Handover with regional delivery officer</h1>
+      <div class="govuk-inset-text">
+        <p class="govuk-body govuk-!-margin-0">
+          <span class="govuk-!-font-weight-bold">First baseline:</span>
+          1 July 2022</p>
+        <p class="govuk-body govuk-!-margin-0">
+          <span class="govuk-!-font-weight-bold">All conditions met baseline:</span>
+          14 July 2022</p>
+          <p class="govuk-body govuk-!-margin-0">
+            <span class="govuk-!-font-weight-bold">Target opening date:</span>
+            1 August 2022</p>
+          <p class="govuk-body govuk-!-margin-0">
+            <span class="govuk-!-font-weight-bold">Incoming trust:</span>
+            Dynamics Trust</p>
+      </div>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h2 class="govuk-heading-l">Project task list</h2>
+          <ol class="app-task-list">
+            <li>
+              <ul class="app-task-list__items">
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="#" aria-describedby="handover-status">
+                      Save handover pro-forma in SharePoint</a>
+                  </span>
+                  <strong class="govuk-tag app-task-list__tag govuk-tag--blue"
+                    id="handover-status">In progress</strong>
+                </li>
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="#" aria-describedby="read-declaration-status">
+                      Check documents</a>
+                  </span>
+                  <strong class="govuk-tag app-task-list__tag govuk-tag--grey"
+                    id="read-declaration-status">Not started</strong>
+                </li>
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="#" aria-describedby="read-declaration-status">
+                      Prepare for regional delivery officer handover</a>
+                  </span>
+                  <strong class="govuk-tag app-task-list__tag govuk-tag--grey"
+                    id="read-declaration-status">Not started</strong>
+                </li>
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="#" aria-describedby="read-declaration-status">
+                      Complete regional delivery officer handover</a>
+                  </span>
+                  <strong class="govuk-tag app-task-list__tag govuk-tag--grey"
+                    id="read-declaration-status">Not started</strong>
+                </li>
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="#" aria-describedby="read-declaration-status">
+                      Get local authority questionnaire</a>
+                  </span>
+                  <strong class="govuk-tag app-task-list__tag govuk-tag--grey"
+                    id="read-declaration-status">Not started</strong>
+                </li>
+              </ul>
+            </li>
+          </ol>
+          {{ govukButton({ text: "Complete project" }) }}
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/0-2/project-kick-off/identify-things-to-discuss.html
+++ b/app/views/0-2/project-kick-off/identify-things-to-discuss.html
@@ -1,0 +1,37 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Complete conversions transfers and changes
+{% endblock %}
+
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block beforeContent %}
+  {% include "../includes/phase.html" %}
+  <a href="../project-task-list" class="govuk-back-link">Back to task list</a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <form action="identify-things-to-discuss" method="post" class="form">
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                  <span class="govuk-caption-l">St. Wilfred's Primary School</span>
+                  <h1 class="govuk-fieldset__heading" for="thingsToDiscussWithRegionalOfficer">
+                    Identify things to discuss with the regional delivery officer</h1>
+                </legend>
+                <textarea class="govuk-textarea" id="thingsToDiscussWithRegionalOfficer" name="thingsToDiscussWithRegionalOfficer" rows="5" aria-describedby="more-detail-hint" >{{data['thingsToDiscussWithRegionalOfficer']}}</textarea>
+              </fieldset>
+            </div>
+            {{ govukButton({ text: "Continue" }) }}
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/0-2/project-kick-off/proforma-url.html
+++ b/app/views/0-2/project-kick-off/proforma-url.html
@@ -1,0 +1,37 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Complete conversions transfers and changes
+{% endblock %}
+
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block beforeContent %}
+  {% include "../includes/phase.html" %}
+  <a href="../project-task-list" class="govuk-back-link">Back to task list</a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <form action="proforma-url" method="post" class="form">
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                  <span class="govuk-caption-l">St. Wilfred's Primary School</span>
+                  <h1 class="govuk-fieldset__heading" for="proformaSharepointURL">What is the URL for the
+                    school's Proforma on sharepoint?</h1>
+                </legend>
+                <input class="govuk-input" id="proformaSharepointURL" name="proformaSharepointURL" type="text" value="{{data['proformaSharepointURL']}}">
+              </fieldset>
+            </div>
+            {{ govukButton({ text: "Continue" }) }}
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/0-2/project-kick-off/save-proforma.html
+++ b/app/views/0-2/project-kick-off/save-proforma.html
@@ -1,0 +1,50 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Complete conversions transfers and changes
+{% endblock %}
+
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block beforeContent %}
+  {% include "../includes/phase.html" %}
+  <a href="../project-task-list" class="govuk-back-link">Back to task list</a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <form action="save-proforma" method="post" class="form">
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                  <span class="govuk-caption-l">St. Wilfred's Primary School</span>
+                  <h1 class="govuk-fieldset__heading">Have you saved pro-forma in
+                    the school's SharePoint folder?</h1>
+                </legend>
+                <div class="govuk-radios" data-module="govuk-radios">
+                  <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="proformaInSharepoint" name="proformaInSharepoint" type="radio" value="Yes" {{ checked("proformaInSharepoint", "yes") }}>
+                    <label class="govuk-label govuk-radios__label" for="proformaInSharepoint">
+                      Yes
+                    </label>
+                  </div>
+                  <div class="govuk-radios__item">
+                    <input class="govuk-radios__input" id="proformaInSharepoint-2" name="proformaInSharepoint" type="radio" value="No, but I have requested the pro-forma" {{ checked("proformaInSharepoint", "no") }}>
+                    <label class="govuk-label govuk-radios__label" for="proformaInSharepoint-2">
+                      No, but I have requested the pro-forma
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+            </div>
+            {{ govukButton({ text: "Continue" }) }}
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/0-2/project-kick-off/trust-model-docs-url.html
+++ b/app/views/0-2/project-kick-off/trust-model-docs-url.html
@@ -1,0 +1,37 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Complete conversions transfers and changes
+{% endblock %}
+
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block beforeContent %}
+  {% include "../includes/phase.html" %}
+  <a href="../project-task-list" class="govuk-back-link">Back to task list</a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <form action="trust-model-docs-url" method="post" class="form">
+            <div class="govuk-form-group">
+              <fieldset class="govuk-fieldset">
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                  <span class="govuk-caption-l">St. Wilfred's Primary School</span>
+                  <h1 class="govuk-fieldset__heading" for="trustModelDocsUrl">What is the URL for the
+                    school's trust model documents?</h1>
+                </legend>
+                <input class="govuk-input" id="trustModelDocsUrl" name="trustModelDocsUrl" type="text" value="{{data['trustModelDocsUrl']}}">
+              </fieldset>
+            </div>
+            {{ govukButton({ text: "Continue" }) }}
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/0-2/project-task-list.html
+++ b/app/views/0-2/project-task-list.html
@@ -31,6 +31,17 @@
             <span class="govuk-!-font-weight-bold">Incoming trust:</span>
             Dynamics Trust</p>
       </div>
+
+      <nav class="sub-navigation" aria-label="Sub navigation">
+        <ul class="sub-navigation__list">
+          <li class="sub-navigation__item">
+            <a class="sub-navigation__link" aria-current="page" href="#">Project task list</a>
+          </li>
+          <li class="sub-navigation__item">
+            <a class="sub-navigation__link" href="project-information">Project information</a>
+          </li>
+        </ul>
+      </nav>
       <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
           <h2 class="govuk-heading-l">Project task list</h2>

--- a/app/views/0-2/project-task-list.html
+++ b/app/views/0-2/project-task-list.html
@@ -1,0 +1,254 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Complete conversions transfers and changes
+{% endblock %}
+
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block beforeContent %}
+  {% include "./includes/phase.html" %}
+  <a href="start" class="govuk-back-link">Back to all projects</a>
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <span class="govuk-caption-l">URN 102062 - Voluntary aided school</span>
+      <h1 class="govuk-heading-l">St. Wilfred's Primary School</h1>
+      <div class="govuk-inset-text">
+        <p class="govuk-body govuk-!-margin-0">
+          <span class="govuk-!-font-weight-bold">First baseline:</span>
+          1 July 2022</p>
+        <p class="govuk-body govuk-!-margin-0">
+          <span class="govuk-!-font-weight-bold">All conditions met baseline:</span>
+          14 July 2022</p>
+          <p class="govuk-body govuk-!-margin-0">
+            <span class="govuk-!-font-weight-bold">Target opening date:</span>
+            1 August 2022</p>
+          <p class="govuk-body govuk-!-margin-0">
+            <span class="govuk-!-font-weight-bold">Incoming trust:</span>
+            Dynamics Trust</p>
+      </div>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+          <h2 class="govuk-heading-l">Project task list</h2>
+          <ol class="app-task-list">
+            <li>
+              <h2 class="app-task-list__section">
+                <span class="app-task-list__section-number">1. </span> Project
+                kick off
+              </h2>
+              <ul class="app-task-list__items">
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="project-kick-off/save-proforma" aria-describedby="handover-status">
+                      Handover with regional delivery officer</a>
+                  </span>
+                  <strong class="govuk-tag app-task-list__tag govuk-tag--blue"
+                    id="handover-status">In progress</strong>
+                </li>
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="#" aria-describedby="read-declaration-status">
+                      Check and update Knowledge Information Management sysytem
+                      (KIM)</a>
+                  </span>
+                  <strong class="govuk-tag app-task-list__tag govuk-tag--grey"
+                    id="read-declaration-status">Not started</strong>
+                </li>
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="#" aria-describedby="read-declaration-status">
+                      Stakeholder kickoff</a>
+                  </span>
+                  <strong class="govuk-tag app-task-list__tag govuk-tag--grey"
+                    id="read-declaration-status">Not started</strong>
+                </li>
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="#" aria-describedby="read-declaration-status">
+                      Process conversion grant</a>
+                  </span>
+                  <strong class="govuk-tag app-task-list__tag govuk-tag--grey"
+                    id="read-declaration-status">Not started</strong>
+                </li>
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="#" aria-describedby="read-declaration-status">
+                      Get local authority questionnaire</a>
+                  </span>
+                  <strong class="govuk-tag app-task-list__tag govuk-tag--grey"
+                    id="read-declaration-status">Not started</strong>
+                </li>
+              </ul>
+            </li>
+
+            <li>
+              <h2 class="app-task-list__section">
+                <span class="app-task-list__section-number">2. </span> Clear
+                legal documents
+              </h2>
+              <ul class="app-task-list__items">
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="#" aria-describedby="contact-details-status">
+                      Land questionnaire and land registry title</a>
+                  </span>
+                  <strong class="govuk-tag app-task-list__tag"
+                    id="contact-details-status">Completed</strong>
+                </li>
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="#" aria-describedby="list-convictions-status">
+                      Supplementary funding agreement</a>
+                  </span>
+                  <strong class="govuk-tag govuk-tag--grey app-task-list__tag"
+                    id="list-convictions-status">Not started</strong>
+                </li>
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="#" aria-describedby="list-convictions-status">
+                      Church supplementary agreement
+                    </a>
+                  </span>
+                  <strong class="govuk-tag govuk-tag--grey app-task-list__tag"
+                    id="financial-evidence-status">Not started</strong>
+                </li>
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="#" aria-describedby="list-convictions-status">
+                      Deed of Novation and Variation
+                    </a>
+                  </span>
+                  <strong class="govuk-tag govuk-tag--grey app-task-list__tag"
+                    id="financial-evidence-status">Not started</strong>
+                </li>
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="#" aria-describedby="list-convictions-status">
+                      Memorandom and Articles of Association
+                    </a>
+                  </span>
+                  <strong class="govuk-tag govuk-tag--grey app-task-list__tag"
+                    id="financial-evidence-status">Not started</strong>
+                </li>
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="#" aria-describedby="list-convictions-status">
+                      Master Funding Agreement
+                    </a>
+                  </span>
+                  <strong class="govuk-tag govuk-tag--grey app-task-list__tag"
+                    id="financial-evidence-status">Not started</strong>
+                </li>
+              </ul>
+            </li>
+
+            <li>
+              <h2 class="app-task-list__section">
+                <span class="app-task-list__section-number">3. </span> Get ready
+                for opening
+              </h2>
+              <ul class="app-task-list__items">
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="#" aria-describedby="contact-details-status">
+                      Baseline checks</a>
+                  </span>
+                  <strong class="govuk-tag app-task-list__tag govuk-tag--grey"
+                    id="contact-details-status">Cannot start yet</strong>
+                </li>
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="#" aria-describedby="list-convictions-status">
+                      Stakeholder checks</a>
+                  </span>
+                  <strong class="govuk-tag app-task-list__tag govuk-tag--grey"
+                    id="contact-details-status">Cannot start yet</strong>
+                </li>
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="#" aria-describedby="list-convictions-status">
+                      Sign off sign worksheet</a>
+                  </span>
+                  <strong class="govuk-tag app-task-list__tag govuk-tag--grey"
+                    id="contact-details-status">Cannot start yet</strong>
+                </li>
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="#" aria-describedby="list-convictions-status">
+                      Confirm all conditions met</a>
+                  </span>
+                  <strong class="govuk-tag app-task-list__tag govuk-tag--grey"
+                    id="contact-details-status">Cannot start yet</strong>
+                </li>
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="#" aria-describedby="list-convictions-status">
+                      Grant funding agreement</a>
+                  </span>
+                  <strong class="govuk-tag app-task-list__tag govuk-tag--grey"
+                    id="contact-details-status">Cannot start yet</strong>
+                </li>
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="#" aria-describedby="list-convictions-status">
+                      Stakeholder handover</a>
+                  </span>
+                  <strong class="govuk-tag app-task-list__tag govuk-tag--grey"
+                    id="contact-details-status">Cannot start yet</strong>
+                </li>
+              </ul>
+            </li>
+
+            <li>
+              <h2 class="app-task-list__section">
+                <span class="app-task-list__section-number">4. </span> After
+                opening
+              </h2>
+              <ul class="app-task-list__items">
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="#" aria-describedby="contact-details-status">
+                      Send redacted documents
+                    </a>
+                  </span>
+                  <strong class="govuk-tag app-task-list__tag govuk-tag--grey"
+                    id="contact-details-status">Cannot start yet</strong>
+                </li>
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="#" aria-describedby="list-convictions-status">
+                      Education and Skills Funding Agency handover</a>
+                  </span>
+                  <strong class="govuk-tag app-task-list__tag govuk-tag--grey"
+                    id="contact-details-status">Cannot start yet</strong>
+                </li>
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="#" aria-describedby="list-convictions-status">
+                      Handover to regional delivery officer</a>
+                  </span>
+                  <strong class="govuk-tag app-task-list__tag govuk-tag--grey"
+                    id="contact-details-status">Cannot start yet</strong>
+                </li>
+                <li class="app-task-list__item">
+                  <span class="app-task-list__task-name">
+                    <a href="#" aria-describedby="list-convictions-status">
+                      Process grant funding
+                    </a>
+                  </span>
+                  <strong class="govuk-tag app-task-list__tag govuk-tag--grey"
+                    id="contact-details-status">Cannot start yet</strong>
+                </li>
+              </ul>
+            </li>
+          </ol>
+          {{ govukButton({ text: "Complete project" }) }}
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/0-2/start.html
+++ b/app/views/0-2/start.html
@@ -1,0 +1,271 @@
+{% extends "layout.html" %}
+
+{% block pageTitle %}
+  Complete conversions transfers and changes
+{% endblock %}
+
+{% from "govuk/components/breadcrumbs/macro.njk" import govukBreadcrumbs %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% block beforeContent %}
+  {% include "./includes/phase.html" %}
+{% endblock %}
+
+{% block content %}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h1 class="govuk-heading-l">
+        Projects (6)
+      </h1>
+      <h2 class="govuk-heading-m">June openers</h2>
+      <dl class="govuk-summary-list govuk-summary-list--school-details govuk-!-margin-bottom-9">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <h2 class="govuk-heading-m govuk-heading-m--school-name">
+              <a href="#" class="govuk-link">Bridgewater County High School</a>
+              <span>- URN 356790</span>
+            </h2>
+          </dt>
+          <dd class="govuk-summary-list__actions">
+            <strong class="govuk-tag govuk-tag--purple">Post Advisory Board
+              </strong>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__value">
+            <span class="govuk-!-font-weight-bold">Incoming trust:</span>
+            TCAT The Challenge Academy Trust
+          </dt>
+          <dd class="govuk-summary-list__actions govuk-summary-list__project-type">
+            Conversion
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__value">
+            <span class="govuk-!-font-weight-bold">School phase / type:</span>
+            Primary, Voluntary controlled school
+          </dt>
+          <dd class="govuk-summary-list__actions">
+            Target opening date: 1 June 2022
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__value">
+            <span class="govuk-!-font-weight-bold">Local authority:</span>
+            Wigan Borough Council
+          </dt>
+          <dd class="govuk-summary-list__actions">
+            All conditions met: 14 May 2022
+          </dd>
+        </div>
+      </dl>
+      <dl class="govuk-summary-list govuk-summary-list--school-details govuk-!-margin-bottom-9">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <h2 class="govuk-heading-m govuk-heading-m--school-name">
+              <a href="#" class="govuk-link">Eastview Grammar School</a>
+              <span>- URN 231763</span>
+            </h2>
+          </dt>
+          <dd class="govuk-summary-list__actions">
+            <strong class="govuk-tag govuk-tag--purple">Post Advisory Board
+              </strong>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__value">
+            <span class="govuk-!-font-weight-bold">Incoming trust:</span>
+            Creating Champions Academy Trust
+          </dt>
+          <dd class="govuk-summary-list__actions govuk-summary-list__project-type">
+            Transfer
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__value">
+            <span class="govuk-!-font-weight-bold">School phase / type:</span>
+            Primary, Community special school
+          </dt>
+          <dd class="govuk-summary-list__actions">
+            Target opening date: 1 June 2022
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__value">
+            <span class="govuk-!-font-weight-bold">Local authority:</span>
+            Islington Borough Council
+          </dt>
+          <dd class="govuk-summary-list__actions">
+            All conditions met: 14 May 2022
+          </dd>
+        </div>
+      </dl>
+      <h2 class="govuk-heading-m">July openers</h2>
+      <dl class="govuk-summary-list govuk-summary-list--school-details govuk-!-margin-bottom-9">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <h2 class="govuk-heading-m govuk-heading-m--school-name">
+              <a href="project-task-list" class="govuk-link">St. Wilfred's Primary School</a>
+              <span>- URN 120620</span>
+            </h2>
+          </dt>
+          <dd class="govuk-summary-list__actions">
+            <strong class="govuk-tag govuk-tag--purple">Post Advisory Board
+              </strong>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__value">
+            <span class="govuk-!-font-weight-bold">Incoming trust:</span>
+            Dynamics Trust
+          </dt>
+          <dd class="govuk-summary-list__actions govuk-summary-list__project-type">
+            Conversion
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__value">
+            <span class="govuk-!-font-weight-bold">School phase / type:</span>
+            Not applicable, Community special school
+          </dt>
+          <dd class="govuk-summary-list__actions">
+            Target opening date: 1 July 2022
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__value">
+            <span class="govuk-!-font-weight-bold">Local authority:</span>
+            Warrington Borough Council
+          </dt>
+          <dd class="govuk-summary-list__actions">
+            All conditions met: 14 June 2022
+          </dd>
+        </div>
+      </dl>
+      <h2 class="govuk-heading-m">August openers</h2>
+      <dl class="govuk-summary-list govuk-summary-list--school-details">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <h2 class="govuk-heading-m govuk-heading-m--school-name">
+              <a href="#" class="govuk-link">Sacred Heart Country Primary School</a>
+              <span>- URN 345342</span>
+            </h2>
+          </dt>
+          <dd class="govuk-summary-list__actions">
+            <strong class="govuk-tag govuk-tag--purple">Post Advisory Board
+              </strong>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__value">
+            <span class="govuk-!-font-weight-bold">Incoming trust:</span>
+            The Oxford Warriors Academy Trust
+          </dt>
+          <dd class="govuk-summary-list__actions govuk-summary-list__project-type">
+            Change
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__value">
+            <span class="govuk-!-font-weight-bold">School phase / type:</span>
+            Not applicable, Foundation special school
+          </dt>
+          <dd class="govuk-summary-list__actions">
+            Target opening date: 1 August 2022
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__value">
+            <span class="govuk-!-font-weight-bold">Local authority:</span>
+            Oxford
+          </dt>
+          <dd class="govuk-summary-list__actions">
+            All conditions met: 14 July 2022
+          </dd>
+        </div>
+      </dl>
+      <dl class="govuk-summary-list govuk-summary-list--school-details govuk-!-margin-bottom-9">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <h2 class="govuk-heading-m govuk-heading-m--school-name">
+              <a href="#" class="govuk-link">Horsendale Primary School</a>
+              <span>- URN 267890</span>
+            </h2>
+          </dt>
+          <dd class="govuk-summary-list__actions">
+            <strong class="govuk-tag govuk-tag--purple">Post Advisory Board
+              </strong>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__value">
+            <span class="govuk-!-font-weight-bold">Incoming trust:</span>
+            Catalyst Academy Trust
+          </dt>
+          <dd class="govuk-summary-list__actions govuk-summary-list__project-type">
+            Conversion
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__value">
+            <span class="govuk-!-font-weight-bold">School phase / type:</span>
+            Primary, Community school
+          </dt>
+          <dd class="govuk-summary-list__actions">
+            Target opening date: 1 August 2022
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__value">
+            <span class="govuk-!-font-weight-bold">Local authority:</span>
+            Primary, Community school
+          </dt>
+          <dd class="govuk-summary-list__actions">
+            All conditions met: 14 July 2022
+          </dd>
+        </div>
+      </dl>
+      <dl class="govuk-summary-list govuk-summary-list--school-details govuk-!-margin-bottom-9">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            <h2 class="govuk-heading-m govuk-heading-m--school-name">
+              <a href="#" class="govuk-link">Abbey Park Middle School</a>
+              <span>- URN 345342</span>
+            </h2>
+          </dt>
+          <dd class="govuk-summary-list__actions">
+            <strong class="govuk-tag govuk-tag--purple">Post Advisory Board
+              </strong>
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__value">
+            <span class="govuk-!-font-weight-bold">Incoming trust:</span>
+            Catalyst Academy Trust
+          </dt>
+          <dd class="govuk-summary-list__actions govuk-summary-list__project-type">
+            Conversion
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__value">
+            <span class="govuk-!-font-weight-bold">School phase / type:</span>
+            Middle deemed primary, Community school
+          </dt>
+          <dd class="govuk-summary-list__actions">
+            Target opening date: 1 August 2022
+          </dd>
+        </div>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__value">
+            <span class="govuk-!-font-weight-bold">Local authority:</span>
+            Oxford
+          </dt>
+          <dd class="govuk-summary-list__actions">
+            All conditions met: 14 July 2022
+          </dd>
+        </div>
+      </dl>
+    </div>
+  </div>
+{% endblock %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -10,6 +10,18 @@
       <h1 class="govuk-heading-xl">
         {{serviceName}}
       </h1>
+      <h2 class="govuk-heading-m">v0.2 Adding the project information tab</h2>
+      <p><a href="0-1/start">View</a></p>
+      <p class="govuk-body">Summary of features for this version:</p>
+      <ul class="govuk-list govuk-list--bullet">
+        <li>
+          <p class="govuk-body"><a href="https://trello.com/c/EvmEPaje/134-recreate-the-project-information-tab-in-prototype">
+            Add in the project information tab.</a></p>
+          <p class="govuk-body">Changes summary:</p>
+          <p class="govuk-body">Use navigation component for consistency with prepare for a conversion.</p>
+          <p class="govuk-body">Add in current information from Figma doc.</p>
+        </li>
+      </ul>
       <h2 class="govuk-heading-m">v0.1 Initial build in code</h2>
       <p><a href="0-1/start">View</a></p>
       <p class="govuk-body">Summary of features for this version:</p>
@@ -21,7 +33,7 @@
           <p class="govuk-body">This work looks at building an initial set up sub
             tasks that may be presented to the user as a discreet journey.</p>
           <p class="govul-body">The status tag of the parent task should update
-            as the user submits information</p>
+            as the user submits information (this is not done yet)</p>
         </li>
         <li>
           <p class="govuk-body"><a href="https://dfe-gov-uk.visualstudio.com.mcas.ms/Academies-and-Free-Schools-SIP/_workitems/edit/98774">

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -11,7 +11,7 @@
         {{serviceName}}
       </h1>
       <h2 class="govuk-heading-m">v0.2 Adding the project information tab</h2>
-      <p><a href="0-1/start">View</a></p>
+      <p><a href="0-2/start">View</a></p>
       <p class="govuk-body">Summary of features for this version:</p>
       <ul class="govuk-list govuk-list--bullet">
         <li>


### PR DESCRIPTION
Create Project information page based on Figma
- Change order of sections as all projects will include a local
  authority but only some will have a diocese
- Group contact information together per person
- Create empty tag based on the prepare for conversion team's code