### PR TITLE
Change project external contacts view to cards

### DIFF
--- a/app/views/0-26/project-external-contacts.html
+++ b/app/views/0-26/project-external-contacts.html
@@ -72,150 +72,130 @@
             <p class="govuk-body">{{data['project-notes']}}</p>
             <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
           {% endif %}
-          <h3 class="govuk-heading-m">School contacts</h3>
-          <dl class="govuk-summary-list">
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Role
-              </dt>
-              <dd class="govuk-summary-list__value">
-                Main contact
-              </dd>
-              <dd class="govuk-summary-list__actions">
-                <a class="govuk-link" href="contacts/edit-contact.html">
-                  Change<span class="govuk-visually-hidden"> contact details</span>
-                </a>
-              </dd>
+          <h3 class="govuk-heading-m" id="school-contacts">School contacts</h3>
+          <!-- summary card -->
+          <div class="govuk-summary-card">
+            <div class="govuk-summary-card__title-wrapper">
+              <h2 class="govuk-summary-card__title">Main contact</h2>
+              <ul class="govuk-summary-card__actions">
+                <li class="govuk-summary-card__action"> <a class="govuk-link" href="#">
+                    Change<span class="govuk-visually-hidden"> main contact</span>
+                  </a>
+                </li>
+              </ul>
             </div>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Name
-              </dt>
-              <dd class="govuk-summary-list__value">
-                Jane Smith
-              </dd>
-              <dd class="govuk-summary-list__actions">
-              </dd>
+            <div class="govuk-summary-card__content">
+              <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    Name
+                  </dt>
+                  <dd class="govuk-summary-list__value">
+                    Jane Smith
+                  </dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    Email
+                  </dt>
+                  <dd class="govuk-summary-list__value">
+                    <a href="#">jane.s@school.com</a>
+                  </dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    Phone
+                  </dt>
+                  <dd class="govuk-summary-list__value">
+                    <a href="#">07785 187463</a>
+                  </dd>
+                </div>
+              </dl>
             </div>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Email
-              </dt>
-              <dd class="govuk-summary-list__value">
-                <a class="govuk-link" href="mailto:jane.s@school.com">
-                  jane.s@school.com</a>
-              </dd>
-              <dd class="govuk-summary-list__actions">
-              </dd>
+          </div>
+          <!-- summary card -->
+          <div class="govuk-summary-card">
+            <div class="govuk-summary-card__title-wrapper">
+              <h2 class="govuk-summary-card__title" id="">Main contact</h2>
+              <ul class="govuk-summary-card__actions">
+                <li class="govuk-summary-card__action"> <a class="govuk-link" href="#">
+                    Change<span class="govuk-visually-hidden"> main contact</span>
+                  </a>
+                </li>
+              </ul>
             </div>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Phone
-              </dt>
-              <dd class="govuk-summary-list__value">
-                <a class="govuk-link" href="tel:07785187463">
-                  07785 187463</a>
-              </dd>
-              <dd class="govuk-summary-list__actions">
-              </dd>
+            <div class="govuk-summary-card__content">
+              <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    Name
+                  </dt>
+                  <dd class="govuk-summary-list__value">
+                    Kevin Carter
+                  </dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    Email
+                  </dt>
+                  <dd class="govuk-summary-list__value">
+                    <a href="#">kevin.c@school.com</a>
+                  </dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    Phone
+                  </dt>
+                  <dd class="govuk-summary-list__value">
+                    <a href="#">1234 567890</a>
+                  </dd>
+                </div>
+              </dl>
             </div>
-          </dl>
-          <dl class="govuk-summary-list">
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Role
-              </dt>
-              <dd class="govuk-summary-list__value">
-                Main contact
-              </dd>
-              <dd class="govuk-summary-list__actions">
-                <a class="govuk-link" href="#">
-                  Change<span class="govuk-visually-hidden" href="contacts/edit-contact.html"> contact details</span>
-                </a>
-              </dd>
-            </div>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Name
-              </dt>
-              <dd class="govuk-summary-list__value">
-                Kevin Carter
-              </dd>
-              <dd class="govuk-summary-list__actions">
-              </dd>
-            </div>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Email
-              </dt>
-              <dd class="govuk-summary-list__value">
-                <a class="govuk-link" href="mailto:kevin.c@school.com">
-                  kevin.c@school.com</a>
-              </dd>
-              <dd class="govuk-summary-list__actions">
-              </dd>
-            </div>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Phone
-              </dt>
-              <dd class="govuk-summary-list__value">
-                <a class="govuk-link" href="tel:1234567890">
-                  1234 567890</a>
-              </dd>
-              <dd class="govuk-summary-list__actions">
-              </dd>
-            </div>
-          </dl>
+          </div>
 
-          <h3 class="govuk-heading-m govuk-!-margin-top-9">Trust contacts</h3>
-          <dl class="govuk-summary-list">
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Role
-              </dt>
-              <dd class="govuk-summary-list__value">
-                Senior finance manager
-              </dd>
-              <dd class="govuk-summary-list__actions">
-                <a class="govuk-link" href="contacts/edit-contact.html">
-                  Change<span class="govuk-visually-hidden"> contact details</span>
-                </a>
-              </dd>
+          <h3 class="govuk-heading-m govuk-!-margin-top-9" id="trust-contacts">Trust contacts</h3>
+          <!-- summary card -->
+          <div class="govuk-summary-card">
+            <div class="govuk-summary-card__title-wrapper">
+              <h2 class="govuk-summary-card__title">Senior finance manager</h2>
+              <ul class="govuk-summary-card__actions">
+                <li class="govuk-summary-card__action"> <a class="govuk-link" href="#">
+                    Change<span class="govuk-visually-hidden"> senior finance manager</span>
+                  </a>
+                </li>
+              </ul>
             </div>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Name
-              </dt>
-              <dd class="govuk-summary-list__value">
-                Bob Belcher
-              </dd>
-              <dd class="govuk-summary-list__actions">
-              </dd>
+            <div class="govuk-summary-card__content">
+              <dl class="govuk-summary-list">
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    Name
+                  </dt>
+                  <dd class="govuk-summary-list__value">
+                    Bob Belcher
+                  </dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    Email
+                  </dt>
+                  <dd class="govuk-summary-list__value">
+                    <a href="#">bob.belcher@trust.com</a>
+                  </dd>
+                </div>
+                <div class="govuk-summary-list__row">
+                  <dt class="govuk-summary-list__key">
+                    Phone
+                  </dt>
+                  <dd class="govuk-summary-list__value">
+                    <a href="#">07986 567890</a>
+                  </dd>
+                </div>
+              </dl>
             </div>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Email
-              </dt>
-              <dd class="govuk-summary-list__value">
-                <a class="govuk-link" href="mailto:bob.belcher@trust.com">
-                  bob.belcher@trust.com</a>
-              </dd>
-              <dd class="govuk-summary-list__actions">
-              </dd>
-            </div>
-            <div class="govuk-summary-list__row">
-              <dt class="govuk-summary-list__key">
-                Phone
-              </dt>
-              <dd class="govuk-summary-list__value">
-                <a class="govuk-link" href="tel:07987654321">
-                  07987 654321</a>
-              </dd>
-              <dd class="govuk-summary-list__actions">
-              </dd>
-            </div>
-          </dl>
+          </div>
+          
         </div>
       </div>
     </div>

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -17,6 +17,9 @@
         <a class="govuk-link" href="https://design-histories.education.gov.uk/complete-conversions-transfers-and-changes" rel="noreferrer noopener" target="_blank">Design history (new tab)</a></p>
       <ul class="govuk-list govuk-list--bullet">
         <li>
+            Improve external contact change link. (<a href="./0-26/project-external-contacts#school-contacts">View</a> | <a href="https://trello.com/c/rbvR4S9z/1656-improve-external-contact-change-link-your-projects-view">Trello</a>)
+        </li>
+        <li>
             <a href="https://trello.com/c/o1RZ3uD7/1852-move-prototype-to-v26-add-dfe-design-system-header">Add DfE design system header.</a>
         </li>
         <li>


### PR DESCRIPTION
Currently external contacts are in a summary list with the ‘change’ link in the action column on the first row opposite role. This gives the appearance only the role can be changed.

This commit changes the contact from a summary list to a summary card. The summary card has action links positioned in the card’s header which better communites that these actions relate to the whole card and not parts of it.

## Before

<img width="858" alt="Screenshot 2023-07-12 at 18 41 02" src="https://github.com/DFE-Digital/complete-conversions-transfers-and-changes-prototype/assets/10995619/31b2819b-b747-497f-a194-7645e34f226e">

## After

<img width="858" alt="Screenshot 2023-07-12 at 18 40 51" src="https://github.com/DFE-Digital/complete-conversions-transfers-and-changes-prototype/assets/10995619/db79a3b3-3316-429c-ba95-ebce8f318db3">

